### PR TITLE
Add renderer property according to Highchart fonctionnality

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Attribute  | Options     | Default              | Description
 `tooltipOptions` | *object* | `{}` | Override/Add Options to your tooltip
 `highchartOptions` | *object* | `{}` | Override/Add Options to the chart initalization code [useful for custom charts]
 `height-responsive` | *Attribute* | `NA` | Make chart height responsive [*define container height for this to work*]
+`renderer` | *object* | `{}` | Allows direct access to the Highcharts rendering layer in order to draw primitive shapes like circles, rectangles,paths or text directly on a chart, or independent from any chart.
 `_chart` | *object `[readonly]`* | `{}` | HighCharts exposed object
 
 **Note:** 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Attribute  | Options     | Default              | Description
 `tooltipOptions` | *object* | `{}` | Override/Add Options to your tooltip
 `highchartOptions` | *object* | `{}` | Override/Add Options to the chart initalization code [useful for custom charts]
 `height-responsive` | *Attribute* | `NA` | Make chart height responsive [*define container height for this to work*]
-`renderer` | *object* | `{}` | Allows direct access to the Highcharts rendering layer in order to draw primitive shapes like circles, rectangles,paths or text directly on a chart, or independent from any chart.
+`renderer` | *object `[readonly]`* | `{}` | Allows direct access to the Highcharts rendering layer in order to draw primitive shapes like circles, rectangles,paths or text directly on a chart, or independent from any chart.
 `_chart` | *object `[readonly]`* | `{}` | HighCharts exposed object
 
 **Note:** 

--- a/highcharts-behavior.html
+++ b/highcharts-behavior.html
@@ -35,7 +35,7 @@
             yZoom: {type: Boolean, value: false, reflectToAttribute: true, observer: "_zoomUpdate"},
             loading: {type: Boolean, value: false, observer: "_loadingUpdate", reflectToAttribute:true},
             loadingMessage: {type: String, value: ""},
-            renderer: {type: Object, computed: "_renderer(_chart)"},
+            renderer: {type: Object, computed: "_renderer(_chart.renderer)"},
             //Custom Chart Declarations
             legendOptions: {type: Object, value: function(){return {}}, observer: "_legendOptionsUpdate"},
             tooltipOptions: {type: Object, value: function(){return {}}, observer: "_tooltipOptionsUpdate"},

--- a/highcharts-behavior.html
+++ b/highcharts-behavior.html
@@ -35,6 +35,7 @@
             yZoom: {type: Boolean, value: false, reflectToAttribute: true, observer: "_zoomUpdate"},
             loading: {type: Boolean, value: false, observer: "_loadingUpdate", reflectToAttribute:true},
             loadingMessage: {type: String, value: ""},
+            renderer: {type: Object, computed: "_renderer(_chart)"},
             //Custom Chart Declarations
             legendOptions: {type: Object, value: function(){return {}}, observer: "_legendOptionsUpdate"},
             tooltipOptions: {type: Object, value: function(){return {}}, observer: "_tooltipOptionsUpdate"},
@@ -143,6 +144,7 @@
         _loadingUpdate: function() {if(!this._chart){return};this._chart[(this.loading?"show":"hide")+"Loading"](this.loadingMessage)},
         _subtitleUpdate: function() {if(!this._chart){return};this._chart.setTitle(null,{text: this.subtitle})},
         _hcUpdate: function(o) {if(!this._chart){return};this._chart.update(o)},
+        _renderer: function() {if(!this._chart){return};return this._chart.renderer},
         //Other Bindings
         _getAxisLabel: function(dim) {var l = dim.toLowerCase(),u = dim.toUpperCase(),lab = this[l+"Label"]||this.label;if(lab==u+"-Axis"){lab=this.label||lab};return lab.trim()},
         _returnDummySeries: function(){var f=function(){};return {isDummy: true, setData: f, addPoint: f, update: f,remove: f}},

--- a/highcharts-behavior.html
+++ b/highcharts-behavior.html
@@ -35,7 +35,7 @@
             yZoom: {type: Boolean, value: false, reflectToAttribute: true, observer: "_zoomUpdate"},
             loading: {type: Boolean, value: false, observer: "_loadingUpdate", reflectToAttribute:true},
             loadingMessage: {type: String, value: ""},
-            renderer: {type: Object, computed: "_renderer(_chart.renderer)"},
+            renderer: {type: Object, computed: "_getRenderer(_chart.renderer)"},
             //Custom Chart Declarations
             legendOptions: {type: Object, value: function(){return {}}, observer: "_legendOptionsUpdate"},
             tooltipOptions: {type: Object, value: function(){return {}}, observer: "_tooltipOptionsUpdate"},
@@ -144,7 +144,7 @@
         _loadingUpdate: function() {if(!this._chart){return};this._chart[(this.loading?"show":"hide")+"Loading"](this.loadingMessage)},
         _subtitleUpdate: function() {if(!this._chart){return};this._chart.setTitle(null,{text: this.subtitle})},
         _hcUpdate: function(o) {if(!this._chart){return};this._chart.update(o)},
-        _renderer: function() {if(!this._chart){return};return this._chart.renderer},
+        _getRenderer: function() {if(!this._chart){return};return this._chart.renderer},
         //Other Bindings
         _getAxisLabel: function(dim) {var l = dim.toLowerCase(),u = dim.toUpperCase(),lab = this[l+"Label"]||this.label;if(lab==u+"-Axis"){lab=this.label||lab};return lab.trim()},
         _returnDummySeries: function(){var f=function(){};return {isDummy: true, setData: f, addPoint: f, update: f,remove: f}},


### PR DESCRIPTION
Hello @avdaredevil,
One more thing!
I added "renderer" property according to specs : http://api.highcharts.com/highcharts/Renderer

It allow us to manipulate chart and add some stuff like that:
this.$.myChart.renderer.image('https://www.maxprog.com/img/cat.jpg', 34.5, 50.5, 50, 50).add();

There "renderer" property is the same as the javascript object.

Thanks! :)
