### PR TITLE
Use the Async method from Polymer 2.0

### DIFF
--- a/highcharts-behavior.html
+++ b/highcharts-behavior.html
@@ -6,6 +6,7 @@
     LinkedIn: https://www.linkedin.com/in/apoorvverma
 |======================================================================*/</script>
 <link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../polymer/lib/utils/async.html">
 <script src="../jquery/dist/jquery.min.js"></script>
 <script src="../highcharts/highstock.js"></script>
 <script src="../highcharts/modules/exporting.js"></script>
@@ -109,7 +110,14 @@
                 const __app = this, isArr = x instanceof Array
                 if (!isArr) {x = $.extend({name: (this.label||this.yLabel||this.xLabel),colorByPoint: this.colorByPoint},x)}
                 if (x && x.length && x[0].data instanceof Array) {
-                    __app.async(function(){while (__app._chart.series.length) {__app.removeSeries(0,false)};x.forEach(function(d){__app._chart.addSeries(d)})},__app.__microTaskDelaySetData)
+                    Polymer.Async.microTask.run(function(){
+                        while (__app._chart.series.length) {
+                            __app.removeSeries(0,false)
+                        };
+                        x.forEach(function(d){
+                            __app._chart.addSeries(d)
+                        })},
+                    __app.__microTaskDelaySetData); 
                 } else {__app._getSeries(z)[isArr?"setData":"update"](x)}
             }
             addData(x,y,z,drillable) {this.pushData(x,y,z,true,drillable)}

--- a/highcharts-behavior.html
+++ b/highcharts-behavior.html
@@ -15,6 +15,10 @@
 <script>
     'use strict';
     Highcharts.setOptions({global: {useUTC: false}})
+    /**
+    @polymer
+    @mixinFunction
+    */
     Highcharts.Polymer_BaseBehavior = function(superClass) {
         const newObj = _ => ({}), newArr = _ => []
         return class extends superClass {
@@ -172,6 +176,10 @@
     }
 
 
+    /**
+    @polymer
+    @mixinFunction
+    */
     Highcharts.Polymer_ChartBehavior = function(superClass) {
         return class extends superClass {
             constructor() {super();this.__addLateBinder("_vsTimeUpdate")}

--- a/highcharts-chart.html
+++ b/highcharts-chart.html
@@ -9,6 +9,12 @@
     </template>
     <script>
         'use strict';
+        /**
+        @polymer
+        @customElement
+        @appliesMixin Highcharts.Polymer_ChartBehavior
+        @appliesMixin Highcharts.Polymer_BaseBehavior
+        */
         class HighchartsChart extends Highcharts.Polymer_ChartBehavior(Highcharts.Polymer_BaseBehavior(Polymer.Element)) {
             static get is() {return 'highcharts-chart'}
             static get properties() {return {

--- a/highcharts-map.html
+++ b/highcharts-map.html
@@ -11,6 +11,11 @@
     </template>
     <script>
         'use strict';
+        /**
+        @polymer
+        @customElement
+        @appliesMixin Highcharts.Polymer_BaseBehavior
+        */
         class HighchartsMap extends Highcharts.Polymer_BaseBehavior(Polymer.Element) {
             static get is() {return 'highcharts-map'}
             static get properties() {return {

--- a/highcharts-stock.html
+++ b/highcharts-stock.html
@@ -9,6 +9,12 @@
     </template>
     <script>
         'use strict';
+        /**
+        @polymer
+        @customElement
+        @appliesMixin Highcharts.Polymer_ChartBehavior
+        @appliesMixin Highcharts.Polymer_BaseBehavior
+        */
         class HighchartsStock extends Highcharts.Polymer_ChartBehavior(Highcharts.Polymer_BaseBehavior(Polymer.Element)) {
             static get is() {return 'highcharts-stock'}
             static get properties() {return {}}


### PR DESCRIPTION
In case of passing multiple data series, an error was raised because a Polymer 1.0 async method was used. This PR modifies the defined behaviour to use Polymer2.0 Async method.